### PR TITLE
fix: reconciliation report generation fails with nautilus-trader >= 1.204.0

### DIFF
--- a/nautilus_gmocoin/execution.py
+++ b/nautilus_gmocoin/execution.py
@@ -16,7 +16,10 @@ from nautilus_trader.model.enums import (
     OrderSide, OrderType, OmsType, AccountType, OrderStatus,
     TimeInForce, LiquiditySide,
 )
-from nautilus_trader.execution.messages import SubmitOrder, CancelOrder, ModifyOrder
+from nautilus_trader.execution.messages import (
+    SubmitOrder, CancelOrder, ModifyOrder,
+    GenerateOrderStatusReports, GenerateFillReports, GeneratePositionStatusReports,
+)
 from nautilus_trader.execution.reports import OrderStatusReport, FillReport, PositionStatusReport
 from nautilus_trader.model.identifiers import TradeId, PositionId
 from nautilus_trader.model.objects import Price, Quantity
@@ -430,9 +433,10 @@ class GmocoinExecutionClient(LiveExecutionClient):
 
     # Required abstract methods
 
-    async def generate_order_status_reports(self, instrument_id=None, client_order_id=None):
+    async def generate_order_status_reports(self, command: GenerateOrderStatusReports) -> list[OrderStatusReport]:
         reports = []
         try:
+            instrument_id = command.instrument_id
             # Determine which symbols to query
             symbols = set()
             if instrument_id:
@@ -597,9 +601,10 @@ class GmocoinExecutionClient(LiveExecutionClient):
             self._logger.error(f"Failed to generate account status reports: {e}", exc_info=True)
             return []
 
-    async def generate_fill_reports(self, instrument_id=None, client_order_id=None):
+    async def generate_fill_reports(self, command: GenerateFillReports) -> list[FillReport]:
         reports = []
         try:
+            instrument_id = command.instrument_id
             symbols = set()
             if instrument_id:
                 symbols.add(instrument_id.symbol.value.split("/")[0])
@@ -664,9 +669,10 @@ class GmocoinExecutionClient(LiveExecutionClient):
 
         return reports
 
-    async def generate_position_status_reports(self, instrument_id=None):
+    async def generate_position_status_reports(self, command: GeneratePositionStatusReports) -> list[PositionStatusReport]:
         reports = []
         try:
+            instrument_id = command.instrument_id
             symbols = set()
             if instrument_id:
                 symbols.add(instrument_id.symbol.value.split("/")[0])


### PR DESCRIPTION
## Summary

- Update `generate_order_status_reports`, `generate_fill_reports`, `generate_position_status_reports` method signatures to accept command objects (`GenerateOrderStatusReports`, `GenerateFillReports`, `GeneratePositionStatusReports`) instead of keyword arguments, matching the nautilus-trader >= 1.204.0 API
- Extract `instrument_id` from `command.instrument_id` instead of receiving it as a direct parameter
- Cancel order empty-data response issue was already fixed in cf9675e

## Root Cause

`LiveExecutionClient` base class passes command objects as positional arguments:

```python
await asyncio.gather(
    self.generate_order_status_reports(order_status_command),
    self.generate_fill_reports(fill_reports_command),
    self.generate_position_status_reports(position_status_command),
)
```

The adapter's old signatures `(self, instrument_id=None, ...)` caused the command object to land in `instrument_id`, then `instrument_id.symbol` failed because command objects have `instrument_id` attribute, not `symbol`.

Closes #1

## Test plan

- [x] All 123 existing tests pass
- [ ] Smoke test with live TradingNode to verify reconciliation completes with reports