### PR TITLE
fix: normalize QuoteTick precision and add pyo3 signatures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nautilus-gmocoin"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [lib]

--- a/nautilus_gmocoin/data.py
+++ b/nautilus_gmocoin/data.py
@@ -122,10 +122,11 @@ class GmocoinDataClient(LiveMarketDataClient):
         ask = data.ask
 
         if bid and ask:
+            precision = instrument.price_precision
             quote = QuoteTick(
                 instrument_id=instrument.id,
-                bid_price=Price.from_str(str(bid)),
-                ask_price=Price.from_str(str(ask)),
+                bid_price=Price(float(bid), precision),
+                ask_price=Price(float(ask), precision),
                 bid_size=Quantity.from_str("0"),
                 ask_size=Quantity.from_str("0"),
                 ts_event=self._clock.timestamp_ns(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nautilus-adapter-gmocoin"
-version = "0.1.2"
+version = "0.1.3"
 description = "GMO Coin adapter for NautilusTrader"
 requires-python = ">=3.12"
 license = { text = "LGPL-3.0-or-later" }

--- a/src/client/execution_client.rs
+++ b/src/client/execution_client.rs
@@ -210,6 +210,7 @@ impl GmocoinExecutionClient {
         pyo3_async_runtimes::tokio::future_into_py(py, future)
     }
 
+    #[pyo3(signature = (symbol, page=None, count=None))]
     pub fn get_active_orders<'py>(
         &self,
         py: Python<'py>,
@@ -229,6 +230,7 @@ impl GmocoinExecutionClient {
         pyo3_async_runtimes::tokio::future_into_py(py, future)
     }
 
+    #[pyo3(signature = (symbol, page=None, count=None))]
     pub fn get_latest_executions<'py>(
         &self,
         py: Python<'py>,
@@ -258,6 +260,7 @@ impl GmocoinExecutionClient {
         self.rest_client.get_margin_py(py)
     }
 
+    #[pyo3(signature = (symbol, page=None, count=None))]
     pub fn get_open_positions<'py>(&self, py: Python<'py>, symbol: String, page: Option<i32>, count: Option<i32>) -> PyResult<Bound<'py, PyAny>> {
         self.rest_client.get_open_positions_py(py, symbol, page, count)
     }


### PR DESCRIPTION
## Summary

DOGE/JPY.GMOCOIN でBOT稼働時に発生した2つの致命的バグを修正:

- **QuoteTick 価格精度の正規化**: GMOコインWSが `bid="48.123"`, `ask="48.12"` のように異なる桁数で送信し、`Price.from_str()` が precision=3 vs precision=2 を生成 → QuoteTick コンストラクタが拒否してデータドロップ。`instrument.price_precision` で統一精度に正規化。
- **pyo3 signature 属性追加**: `get_active_orders`, `get_latest_executions`, `get_open_positions` に `#[pyo3(signature)]` がなく、`Option<i32>` の `page`/`count` が Python 側で必須引数扱い → reconciliation 失敗。`submit_order` と同じパターンで修正。
- バージョン `0.1.2` → `0.1.3` に更新

## Test plan

- [ ] `cargo build --release` でコンパイル確認
- [ ] `pytest tests/` で既存テスト通過確認
- [ ] v0.1.3 タグ作成 → Release CI で wheel ビルド
- [ ] DOGE/JPY BOT で QuoteTick が正常にフィードされることを確認
- [ ] reconciliation が page/count なしで正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)