### PR TITLE
feat: implement generate_order_status_report for single order query

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nautilus-gmocoin"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nautilus-adapter-gmocoin"
-version = "0.1.3"
+version = "0.1.4"
 description = "GMO Coin adapter for NautilusTrader"
 requires-python = ">=3.12"
 license = { text = "LGPL-3.0-or-later" }


### PR DESCRIPTION
## Summary

- BOT再起動時に ExecEngine が PENDING_CANCEL 状態の stale order を reconcile するため `generate_order_status_report`（単数形）を呼び出すが、未実装で `NotImplementedError` が発生していた
- 既存の Rust `get_order` エンドポイント (`/v1/orders?orderId=<id>`) を利用して単一注文のクエリを実装
- パース処理を `_parse_order_status_report` ヘルパーに抽出し、既存の `generate_order_status_reports`（複数形）と共通化

## Changes

- `generate_order_status_report` メソッド追加: `venue_order_id` で1件の注文を REST API 経由で取得し `OrderStatusReport` を返却（未検出時は `None`）
- `_parse_order_status_report` ヘルパー抽出: 注文データのパースロジックを共通化
- `generate_order_status_reports` リファクタ: インラインパースを共通ヘルパー呼び出しに置換
- GMO ステータス/タイプ/TIF マッピング辞書をクラス属性に昇格
- バージョン `0.1.3` → `0.1.4`

## Test plan

- [ ] `cargo build --release` でコンパイル確認（Rust 変更なし）
- [ ] `pytest tests/` で既存テスト通過確認
- [ ] BOT再起動後のログで `NotImplementedError` が消え、stale order が正常に reconcile されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)