### PR TITLE
fix: correct balance truncation, WS field names, and execution event handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nautilus-gmocoin"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nautilus-adapter-gmocoin"
-version = "0.1.4"
+version = "0.1.5"
 description = "GMO Coin adapter for NautilusTrader"
 requires-python = ">=3.12"
 license = { text = "LGPL-3.0-or-later" }


### PR DESCRIPTION
## Summary

本番BOTに影響していた3つの重大バグを修正:

- **残高 `int()` 切り捨て修正**: `int(Decimal(...))` を `Decimal(...)` に変更し、1未満の暗号資産残高（例: 0.05 SOL）が0に切り捨てられる問題を解消。`_process_asset_update` (WS) と `generate_account_status_reports` (REST) の両方を修正
- **ExecutionUpdate専用ハンドラ追加**: `executionEvents` チャンネルのWSメッセージを新メソッド `_process_execution_update` で処理。正確なフィールド名（`executionPrice`, `executionSize`, `fee`, `executionId`）を使用し、`executionId` ベースの重複排除を実装
- **OrderUpdateのWSフィールド名修正**: `orderStatus`, `orderExecutedSize`, `orderPrice` を優先し、REST APIフォールバック（`status`, `executedSize`, `price`）を維持
- **LiquiditySide推定**: `_infer_liquidity_side` ヘルパーを追加（MARKET→TAKER, LIMIT→MAKER, post_only→MAKER）

### 重複排除の設計

ExecutionUpdateとOrderUpdateが同一fillに対して両方届く場合:
1. ExecutionUpdate先着 → `reported_trades` にexecutionId追加、`last_executed_qty` 更新
2. OrderUpdate後着 → `executed_qty <= last_executed_qty` でfill生成スキップ
3. OrderUpdate先着 → fill生成後 `last_executed_qty` 更新、ExecutionUpdate着信時に `reported_trades` で重複検出

## Test plan

- [ ] `python -c "import ast; ast.parse(open('nautilus_gmocoin/execution.py').read())"` でシンタックスOK確認済み
- [ ] BOT再起動後、AccountStateログでSOL残高が0でないこと（例: `0.05000000 SOL`）
- [ ] 約定時のfillログで `last_px` が0でないこと
- [ ] `trade_log` テーブルの `price`, `commission` カラムに正しい値が入ること
- [ ] ExecutionUpdateとOrderUpdateの重複fillが発生しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)