### PR TITLE
chore: bump version to 0.1.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nautilus-gmocoin"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nautilus-adapter-gmocoin"
-version = "0.1.6"
+version = "0.1.7"
 description = "GMO Coin adapter for NautilusTrader"
 requires-python = ">=3.12"
 license = { text = "LGPL-3.0-or-later" }


### PR DESCRIPTION
## Summary

- バージョンを 0.1.6 → 0.1.7 にバンプ
- v0.1.6 は既にリリース済みのため、PR #9 (`liquidity → liquidity_side` 修正) を含む新リリースにはバージョンアップが必要

## 変更

- `pyproject.toml`: version 0.1.6 → 0.1.7
- `Cargo.toml`: version 0.1.6 → 0.1.7

## リリース内容 (v0.1.7)

- fix: `liquidity` → `liquidity_side` in `generate_order_filled()` (#9)
  - NautilusTrader 1.222.0 でのパラメータ名変更に対応
  - 全WebSocket fill eventの TypeError を解消