### PR TITLE
fix: Wrap Decimal values with Quantity/Price in generate_order_filled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nautilus-gmocoin"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 
 [lib]

--- a/nautilus_gmocoin/execution.py
+++ b/nautilus_gmocoin/execution.py
@@ -338,7 +338,7 @@ class GmocoinExecutionClient(LiveExecutionClient):
 
         return order
 
-    def _find_instrument(self, instrument_id: InstrumentId):
+    def _find_instrument(self, instrument_id: InstrumentId) -> Optional["Instrument"]:
         """Find instrument from provider or cache."""
         instrument = self._instrument_provider.find(instrument_id)
         if instrument is None:

--- a/nautilus_gmocoin/execution.py
+++ b/nautilus_gmocoin/execution.py
@@ -43,6 +43,8 @@ class GmocoinExecutionClient(LiveExecutionClient):
 
     _CLIENT_OID_LOOKUP_RETRIES = 10
     _CLIENT_OID_LOOKUP_DELAY_S = 0.1
+    _DEFAULT_QTY_PRECISION = 8
+    _DEFAULT_PX_PRECISION = 0
 
     def __init__(self, loop, config: GmocoinExecClientConfig, msgbus, cache, clock, instrument_provider: InstrumentProvider):
         super().__init__(
@@ -441,9 +443,9 @@ class GmocoinExecutionClient(LiveExecutionClient):
             return instrument.size_precision, instrument.price_precision
         self._logger.warning(
             f"Could not find instrument {instrument_id}. "
-            f"Falling back to default precisions (qty=8, px=0)."
+            f"Falling back to default precisions (qty={self._DEFAULT_QTY_PRECISION}, px={self._DEFAULT_PX_PRECISION})."
         )
-        return 8, 0
+        return self._DEFAULT_QTY_PRECISION, self._DEFAULT_PX_PRECISION
 
     async def _process_order_update_from_data(self, venue_order_id: VenueOrderId, data: dict):
         order = await self._lookup_order_with_retry(venue_order_id)

--- a/nautilus_gmocoin/execution.py
+++ b/nautilus_gmocoin/execution.py
@@ -342,7 +342,10 @@ class GmocoinExecutionClient(LiveExecutionClient):
         """Find instrument from provider or cache."""
         instrument = self._instrument_provider.find(instrument_id)
         if instrument is None:
-            instrument = self._cache.instrument(instrument_id)
+            try:
+                instrument = self._cache.instrument(instrument_id)
+            except KeyError:
+                instrument = None
         return instrument
 
     def _get_quote_currency(self, instrument_id: InstrumentId):

--- a/nautilus_gmocoin/execution.py
+++ b/nautilus_gmocoin/execution.py
@@ -383,6 +383,11 @@ class GmocoinExecutionClient(LiveExecutionClient):
             quote_currency = self._get_quote_currency(order.instrument_id)
             commission = Money(fee, quote_currency)
 
+            # Get instrument precision for proper type wrapping
+            instrument = self._cache.instrument(order.instrument_id)
+            qty_precision = instrument.size_precision if instrument else 8
+            px_precision = instrument.price_precision if instrument else 0
+
             self.generate_order_filled(
                 strategy_id=order.strategy_id,
                 instrument_id=order.instrument_id,
@@ -392,8 +397,8 @@ class GmocoinExecutionClient(LiveExecutionClient):
                 trade_id=TradeId(execution_id),
                 order_side=order.side,
                 order_type=order.order_type,
-                last_qty=exec_size,
-                last_px=exec_price,
+                last_qty=Quantity(exec_size, precision=qty_precision),
+                last_px=Price(exec_price, precision=px_precision),
                 quote_currency=quote_currency,
                 liquidity_side=self._infer_liquidity_side(order),
                 commission=commission,
@@ -486,6 +491,11 @@ class GmocoinExecutionClient(LiveExecutionClient):
                 except Exception as e:
                     self._logger.warning(f"Failed to fetch execution details: {e}")
 
+                # Get instrument precision for proper type wrapping
+                instrument = self._cache.instrument(order.instrument_id)
+                qty_precision = instrument.size_precision if instrument else 8
+                px_precision = instrument.price_precision if instrument else 0
+
                 self.generate_order_filled(
                     strategy_id=order.strategy_id,
                     instrument_id=order.instrument_id,
@@ -495,8 +505,8 @@ class GmocoinExecutionClient(LiveExecutionClient):
                     trade_id=None,
                     order_side=order.side,
                     order_type=order.order_type,
-                    last_qty=delta,
-                    last_px=avg_price,
+                    last_qty=Quantity(delta, precision=qty_precision),
+                    last_px=Price(avg_price, precision=px_precision),
                     quote_currency=quote_currency,
                     liquidity_side=self._infer_liquidity_side(order),
                     commission=commission,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nautilus-adapter-gmocoin"
-version = "0.1.8"
+version = "0.1.9"
 description = "GMO Coin adapter for NautilusTrader"
 requires-python = ">=3.12"
 license = { text = "LGPL-3.0-or-later" }


### PR DESCRIPTION
## Summary
- `_process_execution_update()` と `_process_order_update()` で `generate_order_filled()` に `Decimal` を直接渡していたため `TypeError` が発生し、**全約定イベントが無視**されていた
- `Quantity()` / `Price()` でラップし、precision は `_cache.instrument()` から動的取得
- 既存の `FillReport` 生成（L821-822）では正しくラップされていたが、WS経由の2箇所が漏れていた

## 影響
- GMOcoin BOT で取引所側の約定が strategy の `on_order_filled()` に到達せず、`total_trades = 0`、損益計算も不可能
- ポジション不整合リスク

## 修正内容
```python
# Before (broken)
last_qty=exec_size,    # Decimal
last_px=exec_price,    # Decimal

# After (fixed)
last_qty=Quantity(exec_size, precision=qty_precision),
last_px=Price(exec_price, precision=px_precision),
```

## Test plan
- [x] `Quantity(exec_size` / `Price(exec_price` がL400-401に存在
- [x] `Quantity(delta` / `Price(avg_price` がL508-509に存在
- [ ] GMOcoin BOT再起動後に `ExecutionUpdate fill:` ログが出力され `on_order_filled` に到達することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)