### PR TITLE
fix: handle slash-less symbol format in bar/execution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nautilus-gmocoin"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 
 [lib]

--- a/nautilus_gmocoin/data.py
+++ b/nautilus_gmocoin/data.py
@@ -10,7 +10,7 @@ from nautilus_trader.model.instruments import Instrument
 from nautilus_trader.model.identifiers import ClientId, Venue
 from .config import GmocoinDataClientConfig
 from .constants import BAR_SPEC_TO_GMO_INTERVAL, BAR_POLL_INTERVALS
-from .symbol_utils import extract_gmo_symbol
+from .symbol_utils import extract_gmo_symbol, extract_quote_currency
 
 try:
     from . import _nautilus_gmocoin as gmocoin
@@ -476,7 +476,7 @@ class GmocoinDataClient(LiveMarketDataClient):
                         native_symbol = instrument_id_str
 
                     base = extract_gmo_symbol(native_symbol)
-                    quote = native_symbol.split("/")[1].upper() if "/" in native_symbol else "JPY"
+                    quote = extract_quote_currency(native_symbol)
 
                     info = symbols_map.get(base)
                     if info:

--- a/nautilus_gmocoin/data.py
+++ b/nautilus_gmocoin/data.py
@@ -10,6 +10,7 @@ from nautilus_trader.model.instruments import Instrument
 from nautilus_trader.model.identifiers import ClientId, Venue
 from .config import GmocoinDataClientConfig
 from .constants import BAR_SPEC_TO_GMO_INTERVAL, BAR_POLL_INTERVALS
+from .symbol_utils import extract_gmo_symbol
 
 try:
     from . import _nautilus_gmocoin as gmocoin
@@ -79,8 +80,8 @@ class GmocoinDataClient(LiveMarketDataClient):
     async def subscribe(self, instruments: List[Instrument]):
         for instrument in instruments:
             symbol = instrument.id.symbol
-            # "BTC/JPY" -> "BTC"
-            gmo_symbol = symbol.value.split("/")[0]
+            # "BTC/JPY" -> "BTC", "BTCJPY" -> "BTC"
+            gmo_symbol = extract_gmo_symbol(symbol.value)
             self._subscribed_instruments[gmo_symbol] = instrument
 
             # Subscribe to all channels for this symbol
@@ -318,7 +319,7 @@ class GmocoinDataClient(LiveMarketDataClient):
             return
 
         instrument_id = bar_type.instrument_id
-        gmo_symbol = instrument_id.symbol.value.split("/")[0]
+        gmo_symbol = extract_gmo_symbol(instrument_id.symbol.value)
         poll_interval = BAR_POLL_INTERVALS.get(gmo_interval, 60)
 
         self._logger.info(
@@ -474,7 +475,7 @@ class GmocoinDataClient(LiveMarketDataClient):
                     else:
                         native_symbol = instrument_id_str
 
-                    base = native_symbol.split("/")[0].upper()
+                    base = extract_gmo_symbol(native_symbol).upper()
                     quote = native_symbol.split("/")[1].upper() if "/" in native_symbol else "JPY"
 
                     info = symbols_map.get(base)

--- a/nautilus_gmocoin/data.py
+++ b/nautilus_gmocoin/data.py
@@ -475,7 +475,7 @@ class GmocoinDataClient(LiveMarketDataClient):
                     else:
                         native_symbol = instrument_id_str
 
-                    base = extract_gmo_symbol(native_symbol).upper()
+                    base = extract_gmo_symbol(native_symbol)
                     quote = native_symbol.split("/")[1].upper() if "/" in native_symbol else "JPY"
 
                     info = symbols_map.get(base)

--- a/nautilus_gmocoin/execution.py
+++ b/nautilus_gmocoin/execution.py
@@ -91,6 +91,20 @@ class GmocoinExecutionClient(LiveExecutionClient):
     def account_id(self) -> AccountId:
         return self._account_id
 
+    def _collect_symbols(self, instrument_id=None) -> set[str]:
+        """Collect GMO base-currency symbols to query.
+
+        If *instrument_id* is given, returns a set with just that symbol.
+        Otherwise iterates the instrument provider for all known instruments.
+        """
+        symbols: set[str] = set()
+        if instrument_id:
+            symbols.add(extract_gmo_symbol(instrument_id.symbol.value))
+        else:
+            for inst in self._instrument_provider.get_all().values():
+                symbols.add(extract_gmo_symbol(inst.id.symbol.value))
+        return symbols
+
     async def _connect(self):
         # Register all currencies
         await self._register_all_currencies()
@@ -706,14 +720,7 @@ class GmocoinExecutionClient(LiveExecutionClient):
         reports = []
         try:
             instrument_id = command.instrument_id
-            # Determine which symbols to query
-            symbols = set()
-            if instrument_id:
-                symbols.add(extract_gmo_symbol(instrument_id.symbol.value))
-            else:
-                for inst in self._instrument_provider.get_all().values() if hasattr(self._instrument_provider.get_all, 'values') else self._instrument_provider.get_all():
-                    symbols.add(extract_gmo_symbol(inst.id.symbol.value))
-
+            symbols = self._collect_symbols(instrument_id)
             if not symbols:
                 symbols.add("BTC")
 
@@ -828,13 +835,7 @@ class GmocoinExecutionClient(LiveExecutionClient):
                     self._logger.warning(f"Failed to fetch executions for order {venue_order_id}: {e}")
                 return reports
 
-            symbols = set()
-            if instrument_id:
-                symbols.add(extract_gmo_symbol(instrument_id.symbol.value))
-            else:
-                for inst in self._instrument_provider.get_all().values() if hasattr(self._instrument_provider.get_all, 'values') else self._instrument_provider.get_all():
-                    symbols.add(extract_gmo_symbol(inst.id.symbol.value))
-
+            symbols = self._collect_symbols(instrument_id)
             if not symbols:
                 symbols.add("BTC")
 
@@ -906,13 +907,7 @@ class GmocoinExecutionClient(LiveExecutionClient):
         reports = []
         try:
             instrument_id = command.instrument_id
-            symbols = set()
-            if instrument_id:
-                symbols.add(extract_gmo_symbol(instrument_id.symbol.value))
-            else:
-                for inst in self._instrument_provider.get_all().values() if hasattr(self._instrument_provider.get_all, 'values') else self._instrument_provider.get_all():
-                    symbols.add(extract_gmo_symbol(inst.id.symbol.value))
-
+            symbols = self._collect_symbols(instrument_id)
             if not symbols:
                 return reports
 

--- a/nautilus_gmocoin/execution.py
+++ b/nautilus_gmocoin/execution.py
@@ -4,6 +4,8 @@ import logging
 from typing import Dict, List, Optional
 from decimal import Decimal
 
+from .symbol_utils import extract_gmo_symbol
+
 from nautilus_trader.live.execution_client import LiveExecutionClient
 from nautilus_trader.common.providers import InstrumentProvider
 from nautilus_trader.model.orders import Order
@@ -122,7 +124,7 @@ class GmocoinExecutionClient(LiveExecutionClient):
             order = command.order
             instrument_id = order.instrument_id
             # "BTC/JPY" -> "BTC" for GMO Coin
-            gmo_symbol = instrument_id.symbol.value.split("/")[0]
+            gmo_symbol = extract_gmo_symbol(instrument_id.symbol.value)
 
             side = "BUY" if order.side == OrderSide.BUY else "SELL"
 
@@ -193,7 +195,7 @@ class GmocoinExecutionClient(LiveExecutionClient):
                 return
 
             instrument_id = command.instrument_id
-            gmo_symbol = instrument_id.symbol.value.split("/")[0]
+            gmo_symbol = extract_gmo_symbol(instrument_id.symbol.value)
 
             await self._rust_client.cancel_order(
                 gmo_symbol,
@@ -707,10 +709,10 @@ class GmocoinExecutionClient(LiveExecutionClient):
             # Determine which symbols to query
             symbols = set()
             if instrument_id:
-                symbols.add(instrument_id.symbol.value.split("/")[0])
+                symbols.add(extract_gmo_symbol(instrument_id.symbol.value))
             else:
                 for inst in self._instrument_provider.get_all().values() if hasattr(self._instrument_provider.get_all, 'values') else self._instrument_provider.get_all():
-                    symbols.add(inst.id.symbol.value.split("/")[0])
+                    symbols.add(extract_gmo_symbol(inst.id.symbol.value))
 
             if not symbols:
                 symbols.add("BTC")
@@ -828,10 +830,10 @@ class GmocoinExecutionClient(LiveExecutionClient):
 
             symbols = set()
             if instrument_id:
-                symbols.add(instrument_id.symbol.value.split("/")[0])
+                symbols.add(extract_gmo_symbol(instrument_id.symbol.value))
             else:
                 for inst in self._instrument_provider.get_all().values() if hasattr(self._instrument_provider.get_all, 'values') else self._instrument_provider.get_all():
-                    symbols.add(inst.id.symbol.value.split("/")[0])
+                    symbols.add(extract_gmo_symbol(inst.id.symbol.value))
 
             if not symbols:
                 symbols.add("BTC")
@@ -906,10 +908,10 @@ class GmocoinExecutionClient(LiveExecutionClient):
             instrument_id = command.instrument_id
             symbols = set()
             if instrument_id:
-                symbols.add(instrument_id.symbol.value.split("/")[0])
+                symbols.add(extract_gmo_symbol(instrument_id.symbol.value))
             else:
                 for inst in self._instrument_provider.get_all().values() if hasattr(self._instrument_provider.get_all, 'values') else self._instrument_provider.get_all():
-                    symbols.add(inst.id.symbol.value.split("/")[0])
+                    symbols.add(extract_gmo_symbol(inst.id.symbol.value))
 
             if not symbols:
                 return reports

--- a/nautilus_gmocoin/symbol_utils.py
+++ b/nautilus_gmocoin/symbol_utils.py
@@ -1,15 +1,16 @@
-"""Utility for extracting GMO Coin base symbol from NautilusTrader symbol values."""
+"""Utility for extracting GMO Coin base/quote symbols from NautilusTrader symbol values."""
 
-# Known quote currencies on GMO Coin
-_QUOTE_CURRENCIES = ("JPY", "USDT", "USD", "BTC")
+# Known quote currencies on GMO Coin (sorted longest-first to avoid suffix ambiguity)
+_QUOTE_CURRENCIES = sorted(("JPY", "USDT", "USD", "BTC"), key=len, reverse=True)
 
 
 def extract_gmo_symbol(symbol_value: str) -> str:
     """Extract base currency from a NautilusTrader symbol value.
 
     Handles both slash format (``"SOL/JPY"`` → ``"SOL"``) and catalog/compact
-    format (``"SOLJPY"`` → ``"SOL"``).  Falls back to the original value if
-    no known quote currency suffix is found.
+    format (``"SOLJPY"`` → ``"SOL"``).  Always returns uppercase.
+    Falls back to the original value (uppercased) if no known quote currency
+    suffix is found.
 
     Parameters
     ----------
@@ -29,3 +30,29 @@ def extract_gmo_symbol(symbol_value: str) -> str:
         if upper.endswith(qc) and len(upper) > len(qc):
             return upper[: -len(qc)]
     return upper
+
+
+def extract_quote_currency(symbol_value: str) -> str:
+    """Extract quote currency from a NautilusTrader symbol value.
+
+    Handles both slash format (``"SOL/JPY"`` → ``"JPY"``) and catalog/compact
+    format (``"SOLJPY"`` → ``"JPY"``).  Always returns uppercase.
+    Falls back to ``"JPY"`` if no known quote currency suffix is found.
+
+    Parameters
+    ----------
+    symbol_value : str
+        The ``Symbol.value`` string, e.g. ``"BTC/JPY"`` or ``"BTCUSDT"``.
+
+    Returns
+    -------
+    str
+        The quote currency, e.g. ``"JPY"``, ``"USDT"``.
+    """
+    if "/" in symbol_value:
+        return symbol_value.split("/")[1].upper()
+    upper = symbol_value.upper()
+    for qc in _QUOTE_CURRENCIES:
+        if upper.endswith(qc) and len(upper) > len(qc):
+            return qc
+    return "JPY"

--- a/nautilus_gmocoin/symbol_utils.py
+++ b/nautilus_gmocoin/symbol_utils.py
@@ -1,0 +1,31 @@
+"""Utility for extracting GMO Coin base symbol from NautilusTrader symbol values."""
+
+# Known quote currencies on GMO Coin
+_QUOTE_CURRENCIES = ("JPY", "USDT", "USD", "BTC")
+
+
+def extract_gmo_symbol(symbol_value: str) -> str:
+    """Extract base currency from a NautilusTrader symbol value.
+
+    Handles both slash format (``"SOL/JPY"`` → ``"SOL"``) and catalog/compact
+    format (``"SOLJPY"`` → ``"SOL"``).  Falls back to the original value if
+    no known quote currency suffix is found.
+
+    Parameters
+    ----------
+    symbol_value : str
+        The ``Symbol.value`` string, e.g. ``"BTC/JPY"`` or ``"BTCJPY"``.
+
+    Returns
+    -------
+    str
+        The base currency, e.g. ``"BTC"``, ``"SOL"``.
+    """
+    if "/" in symbol_value:
+        return symbol_value.split("/")[0]
+    # Compact / catalog format: strip known quote currency suffix
+    upper = symbol_value.upper()
+    for qc in _QUOTE_CURRENCIES:
+        if upper.endswith(qc) and len(upper) > len(qc):
+            return upper[: -len(qc)]
+    return symbol_value

--- a/nautilus_gmocoin/symbol_utils.py
+++ b/nautilus_gmocoin/symbol_utils.py
@@ -1,7 +1,7 @@
 """Utility for extracting GMO Coin base/quote symbols from NautilusTrader symbol values."""
 
 # Known quote currencies on GMO Coin (sorted longest-first to avoid suffix ambiguity)
-_QUOTE_CURRENCIES = sorted(("JPY", "USDT", "USD", "BTC"), key=len, reverse=True)
+_QUOTE_CURRENCIES = tuple(sorted(("JPY", "USDT", "USD", "BTC"), key=len, reverse=True))
 
 
 def extract_gmo_symbol(symbol_value: str) -> str:

--- a/nautilus_gmocoin/symbol_utils.py
+++ b/nautilus_gmocoin/symbol_utils.py
@@ -22,10 +22,10 @@ def extract_gmo_symbol(symbol_value: str) -> str:
         The base currency, e.g. ``"BTC"``, ``"SOL"``.
     """
     if "/" in symbol_value:
-        return symbol_value.split("/")[0]
+        return symbol_value.split("/")[0].upper()
     # Compact / catalog format: strip known quote currency suffix
     upper = symbol_value.upper()
     for qc in _QUOTE_CURRENCIES:
         if upper.endswith(qc) and len(upper) > len(qc):
             return upper[: -len(qc)]
-    return symbol_value
+    return upper

--- a/tests/test_symbol_utils.py
+++ b/tests/test_symbol_utils.py
@@ -1,7 +1,7 @@
-"""Tests for symbol_utils.extract_gmo_symbol."""
+"""Tests for symbol_utils.extract_gmo_symbol and extract_quote_currency."""
 
 import pytest
-from nautilus_gmocoin.symbol_utils import extract_gmo_symbol
+from nautilus_gmocoin.symbol_utils import extract_gmo_symbol, extract_quote_currency
 
 
 @pytest.mark.parametrize(
@@ -38,3 +38,28 @@ from nautilus_gmocoin.symbol_utils import extract_gmo_symbol
 )
 def test_extract_gmo_symbol(input_val: str, expected: str):
     assert extract_gmo_symbol(input_val) == expected
+
+
+@pytest.mark.parametrize(
+    "input_val, expected",
+    [
+        # Slash format
+        ("BTC/JPY", "JPY"),
+        ("SOL/USDT", "USDT"),
+        ("ETH/USD", "USD"),
+        ("XRP/BTC", "BTC"),
+        # Compact format
+        ("BTCJPY", "JPY"),
+        ("SOLUSDT", "USDT"),
+        ("ETHUSD", "USD"),
+        ("XRPBTC", "BTC"),
+        # Lowercase / mixed case
+        ("btc/jpy", "JPY"),
+        ("solusdt", "USDT"),
+        ("Btc/Jpy", "JPY"),
+        # Edge: no known quote → default JPY
+        ("BTC", "JPY"),
+    ],
+)
+def test_extract_quote_currency(input_val: str, expected: str):
+    assert extract_quote_currency(input_val) == expected

--- a/tests/test_symbol_utils.py
+++ b/tests/test_symbol_utils.py
@@ -21,9 +21,19 @@ from nautilus_gmocoin.symbol_utils import extract_gmo_symbol
         ("ETHJPY", "ETH"),
         ("DOGEJPY", "DOGE"),
         ("BTCUSDT", "BTC"),
+        # Lowercase slash format
+        ("btc/jpy", "BTC"),
+        ("sol/jpy", "SOL"),
+        # Lowercase compact format
+        ("soljpy", "SOL"),
+        ("btcjpy", "BTC"),
+        # Mixed case
+        ("Btc/Jpy", "BTC"),
+        ("BtcJpy", "BTC"),
         # Edge: already base only
         ("BTC", "BTC"),
         ("SOL", "SOL"),
+        ("sol", "SOL"),
     ],
 )
 def test_extract_gmo_symbol(input_val: str, expected: str):

--- a/tests/test_symbol_utils.py
+++ b/tests/test_symbol_utils.py
@@ -1,0 +1,30 @@
+"""Tests for symbol_utils.extract_gmo_symbol."""
+
+import pytest
+from nautilus_gmocoin.symbol_utils import extract_gmo_symbol
+
+
+@pytest.mark.parametrize(
+    "input_val, expected",
+    [
+        # Slash format (standard NautilusTrader)
+        ("BTC/JPY", "BTC"),
+        ("SOL/JPY", "SOL"),
+        ("XRP/JPY", "XRP"),
+        ("ETH/JPY", "ETH"),
+        ("DOGE/JPY", "DOGE"),
+        ("BTC/USDT", "BTC"),
+        # Compact / catalog format (no slash)
+        ("BTCJPY", "BTC"),
+        ("SOLJPY", "SOL"),
+        ("XRPJPY", "XRP"),
+        ("ETHJPY", "ETH"),
+        ("DOGEJPY", "DOGE"),
+        ("BTCUSDT", "BTC"),
+        # Edge: already base only
+        ("BTC", "BTC"),
+        ("SOL", "SOL"),
+    ],
+)
+def test_extract_gmo_symbol(input_val: str, expected: str):
+    assert extract_gmo_symbol(input_val) == expected


### PR DESCRIPTION
## Summary
- Add `extract_gmo_symbol()` utility in `symbol_utils.py` that handles both slash (`SOL/JPY` → `SOL`) and catalog/compact (`SOLJPY` → `SOL`) symbol formats
- Replace all `symbol.value.split("/")[0]` calls in `data.py` and `execution.py` with `extract_gmo_symbol()`
- Add unit tests for the new utility

## Problem
When `bar_type` uses NautilusTrader catalog format (e.g. `SOLJPY.GMOCOIN-5-MINUTE-LAST-EXTERNAL`), the existing `split("/")[0]` returns `"SOLJPY"` instead of `"SOL"`, causing GMO API to return `status=2: Not found` on every bar poll.

This happens in cross-exchange strategies where instruments are referenced via catalog-format identifiers.

## Test plan
- [x] `test_symbol_utils.py` — parametrized tests for slash, compact, and edge cases
- [x] Verified in production: CES SOL/JPY GMO↔BINANCE node receives bars correctly after patch