### PR TITLE
chore: bump version to 0.1.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nautilus-gmocoin"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
v0.1.11 の whl が旧コードでビルドされていたため、正しいコード (symbol_utils.py 含む) で再ビルドするためのバージョンバンプ。