### PR TITLE
fix: sync pyproject.toml version to 0.1.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nautilus-adapter-gmocoin"
-version = "0.1.10"
+version = "0.1.12"
 description = "GMO Coin adapter for NautilusTrader"
 requires-python = ">=3.12"
 license = { text = "LGPL-3.0-or-later" }


### PR DESCRIPTION
pyproject.toml の version が 0.1.10 のまま更新されていなかったため、whl ファイル名が正しくビルドされなかった。Cargo.toml と pyproject.toml のバージョンを一致させる。