### PR TITLE
chore: bump version to 0.1.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nautilus-gmocoin"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nautilus-adapter-gmocoin"
-version = "0.1.12"
+version = "0.1.13"
 description = "GMO Coin adapter for NautilusTrader"
 requires-python = ">=3.12"
 license = { text = "LGPL-3.0-or-later" }


### PR DESCRIPTION
Cargo.toml + pyproject.toml を同時にバンプ。v0.1.12 は pyproject.toml 不一致で whl ファイル名が 0.1.10 だったため、正しいビルドとしてリリースする。